### PR TITLE
Updated for more recent ElasticSearch Versions

### DIFF
--- a/relevant_children.sh
+++ b/relevant_children.sh
@@ -43,13 +43,10 @@ curl "localhost:9200/test-idx/doc/_search?pretty=true" -d '{
             "type": "score",
             "score_type" : "sum",
             "query" : {
-                "custom_score": {
-                    "script": "doc[\"score.points\"].value * 10",
-                    "query": {
-                        "term" : {
-                            "point_type" : "odd"
+                "function_score": {
+                        "script_score": {
+                                "script": "doc[\"score.points\"].value * 10"
                         }
-                    }
                 }
             }
         }


### PR DESCRIPTION
custom_score has been deprecated and been replaced by function_score with a script_score now.

In order for this to work, scripting must be enabled in elasticsearch.yml:
script.disable_dynamic: false
See also: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-scripting.html
